### PR TITLE
Systemd service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+# Install, uninstall, or manage the grape2.service systemd service
+# which manages the main data collection process "datactrlr"
+#
+# Must be run as root.
+#
+# usage:  sudo make
+
+# name of the service to manage
+SERVICE=grape2
+
+# directory tree where to install the script
+PREFIX=/usr/local
+
+
+# action when calling with no argument
+default: uninstall install enable start
+
+
+# set the location of the installed script
+# uncomment if this customization is needed
+#$(SERVICE).service: $(SERVICE).service.in
+#	sed 's,PREFIX,$(PREFIX),' $< > $@
+
+install: $(SERVICE).service $(SERVICE).env
+	#install --mode=755 $(SERVICE) $(PREFIX)/bin/
+	install --mode=600 $(SERVICE).env /etc/default/
+	install --mode=644 $(SERVICE).service /usr/lib/systemd/system/
+	install -d /var/run/$(SERVICE)
+	mkfifo /var/run/$(SERVICE)/datactrlr.fifo
+
+
+uninstall: disable
+	#rm $(PREFIX)/bin/$(SERVICE)
+	rm /etc/default/$(SERVICE).env
+	rm /usr/lib/systemd/system/$(SERVICE).service
+	rm /var/run/$(SERVICE)/datactrlr.fifo
+
+enable: install
+	systemctl enable $(SERVICE).service
+
+start: install reload
+	systemctl start $(SERVICE).service
+
+restart: install reload
+	systemctl restart $(SERVICE).service
+
+reload:
+	systemctl daemon-reload
+
+disable: stop
+	systemctl disable $(SERVICE).service
+
+stop:
+	systemctl stop $(SERVICE).service
+

--- a/grape2.env
+++ b/grape2.env
@@ -1,0 +1,5 @@
+# these are environment variables for the service
+
+# not used, an example of sending something to the process's environment
+GRAPE2_DATACTRLR_INPUT="/var/run/grape2/datactrlr.fifo"
+

--- a/grape2.service
+++ b/grape2.service
@@ -1,0 +1,50 @@
+[Unit]
+Description=Grape2 data controller service
+After=network.target
+
+# Never Give Up.  disable the # restarts before it gives up and never retries.
+StartLimitIntervalSec=0
+
+
+[Service]
+Type=simple
+
+# run or restart, unless manually stopped (or disabled)
+Restart=always
+
+# wait this time before restarting after a (un)graceful exit
+RestartSec=10
+
+User=root
+
+# run this before
+#   "journalctl -u grape2.service" is 'better', this just demonstrates running
+#   some command before the main one
+ExecStartPre=/usr/bin/bash -c 'echo "Starting service..."; date -u -Is >> /home/pi/test.log; env >> /home/pi/test.log'
+
+# the main process to run
+# run under Bash so we can redirect the named pipe as input for process comms
+ExecStart=/usr/bin/bash -c '/home/pi/G2User/datactrlr -l < /var/run/grape2/datactrlr.fifo'
+
+# (testing) only have one ExecStart uncommented!
+#   the '<>' opens the named pipe in read-write, needed to keep it open after
+#   echo in ExecStartPost finishes.'
+#ExecStart=/usr/bin/bash -c 'cat <>/var/run/grape2/datactrlr.fifo >> /home/pi/test.log'
+
+# This file holds environment variables to be made available to the process
+# e.g. passwords or config values.  Just a placeholder for demo.
+EnvironmentFile=-/etc/default/grape2.env
+
+# Once the ExecStart is ... started, run this command (can be more than one).
+#   send the "r\n" to datactrlr to command it to actually start its stuff.
+ExecStartPost=/usr/bin/bash -c 'sleep 5; echo "r" >> /var/run/grape2/datactrlr.fifo'
+
+# run this when you say "systemctl stop grape2.service"
+# otherwise it gets send a SIGTERM signal
+#   emulate the behavior of G2console.py
+ExecStop=/usr/bin/bash -c '(printf "\x1b"; sleep 0.1; echo "q") >> /var/run/grape2/datactrlr.fifo'
+
+
+[Install]
+WantedBy=multi-user.target
+

--- a/ur.sh
+++ b/ur.sh
@@ -7,3 +7,6 @@ git reset --hard HEAD
 git merge '@{u}'
 ls -al ondeck/
 sudo mv ondeck/* .
+
+# reinstall and restart the grape2 service
+sudo make


### PR DESCRIPTION
Automatically start and run the `datactrlr` under control of systemd as a service.

See the status:
`sudo systemctl status grape2.service`

replace "status" with "start" or "stop" for those actions.

Installing the setup is wrapped up into the Makefile:
`sudo make`  will do everything and get it running.

Another commit changes `G2console.py` to run the `systemctl ...` commands from `g2c`.  It adds a line to inform the user how to exit **without** stopping the Data Controller.

Update `ur.sh` to reinstall/restart the service to pick up any configuration or binary changes.
